### PR TITLE
Enabled discoverable credentials for use with latest HAAPI UI SDKs

### DIFF
--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -44,9 +44,10 @@
                             <id>Passkeys</id>
                             <required-authenticator-for-registration>HtmlForm</required-authenticator-for-registration>
                             <passkeys xmlns="https://curity.se/ns/conf/authenticators/passkeys">
-                            <account-manager>
+                              <enable-discoverable-credentials>true</enable-discoverable-credentials>
+                              <account-manager>
                                 <id>default-account-manager</id>
-                            </account-manager>
+                              </account-manager>
                             </passkeys>
                         </authenticator>
                     </authenticators>


### PR DESCRIPTION
Merge this when the Android HAAPI UI SDK 4.4 is released:
- Merge the [mobile-deployments pull request](https://github.com/curityio/mobile-deployments/pull/13) to enable discoverable credentials.