### PR TITLE
README + Deployment Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ output.txt
 *.key
 *.bks
 *.jar
+certs

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you use ngrok and you have a suitable license file you can also sign into the
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`
 
-You may also need to trust the certificate at `resources/ssl-cert.pem` for the dashboard to work.\
+You may also need to trust the `localhost` certificate at `resources/ssl-cert.pem` for the dashboard to succesfully make fetch requests.\
 For example, on macOS:
 
 - Import the certificate into Keychain Access under `System / Certificates`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you use ngrok and you have a suitable license file you can also sign into the
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`
 
-You may also need to trust the `localhost` certificate at `resources/ssl-cert.pem` for the dashboard to succesfully make fetch requests. For example, on macOS:
+You may also need to trust the `localhost` certificate at `resources/ssl-cert.pem` for the dashboard to successfully make fetch requests. For example, on macOS:
 
 - Import the certificate into Keychain Access under `System / Certificates`.
 - The configure `Always Trust` for the `curityserver` certificate.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ If you use ngrok you can also sign into the DevOps Dashboard and create test use
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`
 
+You may also need to trust the certificate at `resources/ssl-cert.pem` for the dashboard to work.\
+For example, import it to Keychain Access under `System / Certificates` and activate `Always Trust`.
+
 ## User Data
 
 You can query user data like accounts and passkeys by connecting to the PostgreSQL database:

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ You can study the resources for a particular code example and apply them to your
 
 ## Administration and Users
 
-Once the Curity Identity Server is deployed, sign in to the Admin UI using the following details:
+After deploying the Curity Identity Server, sign in to the Admin UI using the following details:
 
 - URL: `https://localhost:6749/admin`
 - User: `admin`
 - Password: `Password1`
 
-Or sign into the DevOps Dashboard and create test user accounts:
+If you use ngrok you can also sign into the DevOps Dashboard and create test user accounts:
 
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`

--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ Each mobile example calls the following script with parameters to start and stop
 
 ## Configuration
 
-The files in the `resources` folder provide base configuration.\
-Different deployment scenarios can apply specific configuration files or override parameters.
+The files in the `resources` folder provide the base configuration.\
+Each code example can apply additional configuration based on its requirements:
 
-For example, HAAPI deployments require a number of technical configuration settings.\
-You can study the resources for a particular code example and apply them to your deployed deployments.
-
-- [HAAPI configuration](haapi/example-config-template.xml)
+- Examples can use default configuration files stored in this project, e.g. in the `appauth` folder.
+- Examples can override configuration by copying in their own configuration files, e.g to the `haapi` folder.
 
 ## Administration and Users
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mobile Deployments
 
-Automated deployments of the Curity Identity Server to provide fast working mobile setups.\
+Automated deployments of the Curity Identity Server to provide initial infrastructure for mobile testing.\
 This repository provides a consistent developer experience for anyone who wants to run mobile examples.
 
 ## Example Applications
 
-The following applications use this repository:
+The following example applications can use this repository:
 
 - [Android Kotlin AppAuth Code Example](https://curity.io/resources/learn/kotlin-android-appauth/)
 - [iOS Swift AppAuth Code Example](https://curity.io/resources/learn/swift-ios-appauth/)
@@ -27,7 +27,7 @@ Each mobile example calls the following script with parameters to start and stop
 
 ## Configuration
 
-The files in the `resources` folder provide base behaviors related to data and user accounts.\
+The files in the `resources` folder provide base configuration.\
 Different deployment scenarios can apply specific configuration files or override parameters.
 
 For example, HAAPI deployments require a number of technical configuration settings.\

--- a/README.md
+++ b/README.md
@@ -35,6 +35,41 @@ You can study the resources for a particular code example and apply them to your
 
 - [HAAPI configuration](haapi/example-config-template.xml)
 
+## Administration and Users
+
+Once the Curity Identity Server is deployed, sign in to the Admin UI using the following details:
+
+- URL: `https://localhost:6749/admin`
+- User: `admin`
+- Password: `Password1`
+
+Or sign into the DevOps Dashboard and create test user accounts:
+
+- URL: `https://localhost:6749/admin/dashboard`
+- User: `admin`
+
+## User Data
+
+You can query user data like accounts and passkeys by connecting to the PostgreSQL database:
+
+```bash
+POSTGRES_CONTAINER=$(docker ps | grep postgres | awk '{print $1}')
+docker exec -it $POSTGRES_CONTAINER bash
+```
+
+Then connect to the database:
+
+```bash
+export PGPASSWORD=Password1 && psql -p 5432 -d idsvr -U postgres
+```
+
+Then query data like user account details or registered passkey public keys:
+
+```text
+select * from accounts;
+select * from devices;
+```
+
 ## More Information
 
 Please visit [curity.io](https://curity.io/) for more information about the Curity Identity Server.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
 # Mobile Deployments
 
-Resources for automating the setup of Curity mobile code examples.
+Automated deployments of the Curity Identity Server to provide fast working mobile setups.\
+This repository provides a consistent developer experience for anyone who wants to run mobile examples.
 
-## Usage
+## Example Applications
 
-This repository is a Git submodule referenced by the below code examples.\
-Run the `./start-idsvr.sh` script for a code example to configure a working mobile OAuth setup.
+The following applications use this repository:
 
-## HAAPI Code Examples
+- [Android Kotlin AppAuth Code Example](https://curity.io/resources/learn/kotlin-android-appauth/)
+- [iOS Swift AppAuth Code Example](https://curity.io/resources/learn/swift-ios-appauth/)
+- [Advanced AppAuth code example using Dynamic Client Registration](https://curity.io/resources/learn/authenticated-dcr-example/)
+- [Android Kotlin HAAPI UI SDK Code Example](https://curity.io/resources/learn/kotlin-android-haapi/)
+- [iOS Swift HAAPI UI SDK Code Example](https://curity.io/resources/learn/swift-ios-haapi/)
+- [React Native HAAPI Code Example](https://curity.io/resources/learn/react-native-haapi/)
+- [Android Kotlin HAAPI Model SDK Code Example](https://github.com/curityio/android-haapi-demo-app)
+- [iOS Swaift HAAPI Model SDK Code Example](https://github.com/curityio/ios-haapi-demo-app)
 
-How to implement OpenID Connect using the Hypermedia Authentication API:
+## Deployment Interface
 
-| Platform | Github Repository |
-| -------- | ----------------- |
-| iOS | https://github.com/curityio/ios-haapi-demo-app |
-| Android | https://github.com/curityio/android-haapi-demo-app |
+Each mobile example calls the following script with parameters to start and stop the Curity Identity Server:
 
-## AppAuth Basic Code Examples
+```bash
+./start.sh
+./stop.sh
+```
 
-How to implement OpenID Connect using the AppAuth Pattern:
+## Configuration
 
-| Platform | Github Repository |
-| -------- | ----------------- |
-| iOS | https://github.com/curityio/openid-client-ios-appauth |
-| Android | https://github.com/curityio/openid-client-android-appauth |
+The files in the `resources` folder provide base behaviors related to data and user accounts.\
+Different deployment scenarios can use their own configuration files and supply parameters.
 
-## AppAuth with Dynamic Client Registration
+For example, HAAPI deployments require a number of technical configuration settings.\
+You can study the resources for a particular code example and apply them to your deployed deployments.
 
-How to implement OpenID Connect with a unique mobile client per device:
-
-| Platform | Github Repository |
-| -------- | ----------------- |
-| iOS | https://github.com/curityio/openid-client-ios-appauth-dcr |
-| Android | https://github.com/curityio/openid-client-android-appauth-dcr |
+- [HAAPI configuration](haapi/example-config-template.xml)
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each mobile example calls the following script with parameters to start and stop
 ## Configuration
 
 The files in the `resources` folder provide base behaviors related to data and user accounts.\
-Different deployment scenarios can use their own configuration files and supply parameters.
+Different deployment scenarios can apply specific configuration files or override parameters.
 
 For example, HAAPI deployments require a number of technical configuration settings.\
 You can study the resources for a particular code example and apply them to your deployed deployments.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ If you use ngrok you can also sign into the DevOps Dashboard and create test use
 - User: `admin`
 
 You may also need to trust the certificate at `resources/ssl-cert.pem` for the dashboard to work.\
-For example, import it to Keychain Access under `System / Certificates` and activate `Always Trust`.
+For example, on macOS:
+
+- Import the certificate into Keychain Access under `System / Certificates`.
+- The configure `Always Trust` for the `curityserver` certificate.
 
 ## User Data
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ If you use ngrok and you have a suitable license file you can also sign into the
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`
 
-You may also need to trust the `localhost` certificate at `resources/ssl-cert.pem` for the dashboard to succesfully make fetch requests.\
-For example, on macOS:
+You may also need to trust the `localhost` certificate at `resources/ssl-cert.pem` for the dashboard to succesfully make fetch requests. For example, on macOS:
 
 - Import the certificate into Keychain Access under `System / Certificates`.
 - The configure `Always Trust` for the `curityserver` certificate.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After deploying the Curity Identity Server, sign in to the Admin UI using the fo
 - User: `admin`
 - Password: `Password1`
 
-If you use ngrok you can also sign into the DevOps Dashboard and create test user accounts:
+If you use ngrok and you have a suitable license file you can also sign into the DevOps Dashboard and create test user accounts:
 
 - URL: `https://localhost:6749/admin/dashboard`
 - User: `admin`

--- a/haapi/configure.sh
+++ b/haapi/configure.sh
@@ -13,20 +13,19 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # - https://github.com/curityio/ios-haapi-demo-app
 #
 if [ "$ANDROID_PACKAGE_NAME" == '' ]; then
-    ANDROID_PACKAGE_NAME='io.curity.haapidemo'
-  fi
-  if [ "$ANDROID_FINGERPRINT" == '' ]; then
-    ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
-  fi
-  if [ "$ANDROID_SIGNATURE_DIGEST" == '' ]; then
-    ANDROID_SIGNATURE_DIGEST='Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ='
-  fi
-  if [ "$APPLE_BUNDLE_ID" == '' ]; then
-    APPLE_BUNDLE_ID='io.curity.haapidemo'
-  fi
-  if [ "$APPLE_TEAM_ID" == '' ]; then
-    APPLE_TEAM_ID='MYTEAMID'
-  fi
+  ANDROID_PACKAGE_NAME='io.curity.haapidemo'
+fi
+if [ "$ANDROID_FINGERPRINT" == '' ]; then
+  ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
+fi
+if [ "$ANDROID_SIGNATURE_DIGEST" == '' ]; then
+  ANDROID_SIGNATURE_DIGEST='Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ='
+fi
+if [ "$APPLE_BUNDLE_ID" == '' ]; then
+  APPLE_BUNDLE_ID='io.curity.cat.ios.client'
+fi
+if [ "$APPLE_TEAM_ID" == '' ]; then
+  APPLE_TEAM_ID='MYTEAMID'
 fi
 
 #

--- a/haapi/configure.sh
+++ b/haapi/configure.sh
@@ -7,29 +7,18 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 #
-# The UI SDK code examples and the React Native code example provide these parameters explicitly
-# The following defaulting of parameters is only used by older HAAPI model SDK code examples
+# The settings file in the haapi/example-config-template.xml file are only used by the model SDK examples
 # - https://github.com/curityio/android-haapi-demo-app
 # - https://github.com/curityio/ios-haapi-demo-app
 #
-if [ "$ANDROID_PACKAGE_NAME" == '' ]; then
-  ANDROID_PACKAGE_NAME='io.curity.haapidemo'
-fi
-if [ "$ANDROID_FINGERPRINT" == '' ]; then
-  ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
-fi
-if [ "$ANDROID_SIGNATURE_DIGEST" == '' ]; then
-  ANDROID_SIGNATURE_DIGEST='Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ='
-fi
-if [ "$APPLE_BUNDLE_ID" == '' ]; then
-  APPLE_BUNDLE_ID='io.curity.cat.ios.client'
-fi
-if [ "$APPLE_TEAM_ID" == '' ]; then
-  APPLE_TEAM_ID='MYTEAMID'
-fi
 
 #
-# All HAAPI examples use a shared configuration to avoid duplication, since there are many configuration settings
+# The UI SDK and React Native examples copy in their own version of the haapi/example-config-template.xml file
+# This allows each HAAPI code example to control its own deployment settings
+#
+
+#
+# Produce the final HAAPI configuration for the deployment
 #
 envsubst < example-config-template.xml > example-config.xml
 if [ $? -ne 0 ]; then

--- a/haapi/configure.sh
+++ b/haapi/configure.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+############################################################
+# Configure HAAPI parameters that vary between code examples
+############################################################
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+#
+# The UI SDK code examples and the React Native code example provide these parameters explicitly
+# The following defaulting of parameters is only used by older HAAPI model SDK code examples
+# - https://github.com/curityio/android-haapi-demo-app
+# - https://github.com/curityio/ios-haapi-demo-app
+#
+if [ "$ANDROID_PACKAGE_NAME" == '' ]; then
+    ANDROID_PACKAGE_NAME='io.curity.haapidemo'
+  fi
+  if [ "$ANDROID_FINGERPRINT" == '' ]; then
+    ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
+  fi
+  if [ "$ANDROID_SIGNATURE_DIGEST" == '' ]; then
+    ANDROID_SIGNATURE_DIGEST='Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ='
+  fi
+  if [ "$APPLE_BUNDLE_ID" == '' ]; then
+    APPLE_BUNDLE_ID='io.curity.haapidemo'
+  fi
+  if [ "$APPLE_TEAM_ID" == '' ]; then
+    APPLE_TEAM_ID='MYTEAMID'
+  fi
+fi
+
+#
+# All HAAPI examples use a shared configuration to avoid duplication, since there are many configuration settings
+#
+envsubst < example-config-template.xml > example-config.xml
+if [ $? -ne 0 ]; then
+  echo 'Problem encountered using envsubst to update example configuration'
+  exit 1
+fi

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -18,7 +18,7 @@
                     <default-zone>
                         <mobile-app-association>
                             <ios-app-configuration>
-                                <app-id>$APPLE_TEAM_ID.$APPLE_APP_ID</app-id>
+                                <app-id>$APPLE_TEAM_ID.$APPLE_BUNDLE_ID</app-id>
                             </ios-app-configuration>
                             <android-app-configuration>
                                 <namespace>android_app</namespace>
@@ -83,7 +83,7 @@
                                 <attestation>
                                 <disable-attestation-validation>true</disable-attestation-validation>
                                 <ios>
-                                    <app-id>$APPLE_APP_ID</app-id>
+                                    <app-id>$APPLE_BUNDLE_ID</app-id>
                                     <ios-policy>ios-dev-policy</ios-policy>
                                 </ios>
                                 </attestation>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -18,13 +18,13 @@
                     <default-zone>
                         <mobile-app-association>
                             <ios-app-configuration>
-                                <app-id>$APPLE_TEAM_ID.$APPLE_BUNDLE_ID</app-id>
+                                <app-id>MYTEAMID.io.curity.cat.ios.client</app-id>
                             </ios-app-configuration>
                             <android-app-configuration>
                                 <namespace>android_app</namespace>
-                                <package-name>$ANDROID_PACKAGE_NAME</package-name>
+                                <package-name>io.curity.haapidemo</package-name>
                                 <sha256-cert-fingerprints>
-                                    <fingerprint>$ANDROID_FINGERPRINT</fingerprint>
+                                    <fingerprint>67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4</fingerprint>
                                 </sha256-cert-fingerprints>
                             </android-app-configuration>
                         </mobile-app-association>
@@ -44,10 +44,9 @@
                             <id>Passkeys</id>
                             <required-authenticator-for-registration>HtmlForm</required-authenticator-for-registration>
                             <passkeys xmlns="https://curity.se/ns/conf/authenticators/passkeys">
-                              <enable-discoverable-credentials>false</enable-discoverable-credentials>
-                              <account-manager>
+                            <account-manager>
                                 <id>default-account-manager</id>
-                              </account-manager>
+                            </account-manager>
                             </passkeys>
                         </authenticator>
                     </authenticators>
@@ -63,10 +62,10 @@
                     <client-store>
                         <config-backed>
                             <client>
-                                <id>haapi-ios-client</id>
+                                <id>haapi-ios-dev-client</id>
                                 <client-name>Haapi iOS Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>haapi://callback</redirect-uris>
+                                <redirect-uris>haapi:start</redirect-uris>
                                 <user-authentication>
                                 </user-authentication>
                                 <scope>address</scope>
@@ -74,10 +73,6 @@
                                 <scope>openid</scope>
                                 <scope>phone</scope>
                                 <scope>profile</scope>
-                                <user-authentication>
-                                    <allowed-authenticators>HtmlForm</allowed-authenticators>
-                                    <allowed-authenticators>Passkeys</allowed-authenticators>
-                                </user-authentication>
                                 <capabilities>
                                     <code/>
                                     <haapi>
@@ -87,7 +82,7 @@
                                 <attestation>
                                 <disable-attestation-validation>true</disable-attestation-validation>
                                 <ios>
-                                    <app-id>$APPLE_BUNDLE_ID</app-id>
+                                    <app-id>io.curity.cat.ios.client</app-id>
                                     <ios-policy>ios-dev-policy</ios-policy>
                                 </ios>
                                 </attestation>
@@ -96,17 +91,13 @@
                                 <id>haapi-android-client</id>
                                 <client-name>Haapi Android Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>haapi://callback</redirect-uris>
+                                <redirect-uris>app://haapi</redirect-uris>
                                 <audience>haapi-client</audience>
                                 <scope>address</scope>
                                 <scope>email</scope>
                                 <scope>openid</scope>
                                 <scope>phone</scope>
                                 <scope>profile</scope>
-                                <user-authentication>
-                                    <allowed-authenticators>HtmlForm</allowed-authenticators>
-                                    <allowed-authenticators>Passkeys</allowed-authenticators>
-                                </user-authentication>
                                 <capabilities>
                                     <code/>
                                     <haapi>
@@ -115,8 +106,8 @@
                                 </capabilities>
                                 <attestation>
                                     <android>
-                                        <package-name>$ANDROID_PACKAGE_NAME</package-name>
-                                        <signature-digest>$ANDROID_SIGNATURE_DIGEST</signature-digest>
+                                        <package-name>io.curity.haapidemo</package-name>
+                                        <signature-digest>Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ=</signature-digest>
                                         <android-policy>android-dev-policy</android-policy>
                                     </android>
                                 </attestation>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -63,10 +63,10 @@
                     <client-store>
                         <config-backed>
                             <client>
-                                <id>haapi-ios-dev-client</id>
+                                <id>haapi-ios-client</id>
                                 <client-name>Haapi iOS Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>haapi://</redirect-uris>
+                                <redirect-uris>haapi://callback</redirect-uris>
                                 <user-authentication>
                                 </user-authentication>
                                 <scope>address</scope>
@@ -92,7 +92,7 @@
                                 <id>haapi-android-client</id>
                                 <client-name>Haapi Android Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>haapi://</redirect-uris>
+                                <redirect-uris>haapi://callback</redirect-uris>
                                 <audience>haapi-client</audience>
                                 <scope>address</scope>
                                 <scope>email</scope>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -44,7 +44,7 @@
                             <id>Passkeys</id>
                             <required-authenticator-for-registration>HtmlForm</required-authenticator-for-registration>
                             <passkeys xmlns="https://curity.se/ns/conf/authenticators/passkeys">
-                              <enable-discoverable-credentials>true</enable-discoverable-credentials>
+                              <enable-discoverable-credentials>false</enable-discoverable-credentials>
                               <account-manager>
                                 <id>default-account-manager</id>
                               </account-manager>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -74,6 +74,10 @@
                                 <scope>openid</scope>
                                 <scope>phone</scope>
                                 <scope>profile</scope>
+                                <user-authentication>
+                                    <allowed-authenticators>HtmlForm</allowed-authenticators>
+                                    <allowed-authenticators>Passkeys</allowed-authenticators>
+                                </user-authentication>
                                 <capabilities>
                                     <code/>
                                     <haapi>
@@ -99,6 +103,10 @@
                                 <scope>openid</scope>
                                 <scope>phone</scope>
                                 <scope>profile</scope>
+                                <user-authentication>
+                                    <allowed-authenticators>HtmlForm</allowed-authenticators>
+                                    <allowed-authenticators>Passkeys</allowed-authenticators>
+                                </user-authentication>
                                 <capabilities>
                                     <code/>
                                     <haapi>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -22,7 +22,7 @@
                             </ios-app-configuration>
                             <android-app-configuration>
                                 <namespace>android_app</namespace>
-                                <package-name>io.curity.haapidemo</package-name>
+                                <package-name>$ANDROID_PACKAGE_NAME</package-name>
                                 <sha256-cert-fingerprints>
                                     <fingerprint>$ANDROID_FINGERPRINT</fingerprint>
                                 </sha256-cert-fingerprints>
@@ -107,7 +107,7 @@
                                 </capabilities>
                                 <attestation>
                                     <android>
-                                        <package-name>io.curity.haapidemo</package-name>
+                                        <package-name>$ANDROID_PACKAGE_NAME</package-name>
                                         <signature-digest>$ANDROID_SIGNATURE_DIGEST</signature-digest>
                                         <android-policy>android-dev-policy</android-policy>
                                     </android>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -44,9 +44,10 @@
                             <id>Passkeys</id>
                             <required-authenticator-for-registration>HtmlForm</required-authenticator-for-registration>
                             <passkeys xmlns="https://curity.se/ns/conf/authenticators/passkeys">
-                            <account-manager>
+                              <enable-discoverable-credentials>true</enable-discoverable-credentials>
+                              <account-manager>
                                 <id>default-account-manager</id>
-                            </account-manager>
+                              </account-manager>
                             </passkeys>
                         </authenticator>
                     </authenticators>

--- a/haapi/example-config-template.xml
+++ b/haapi/example-config-template.xml
@@ -66,7 +66,7 @@
                                 <id>haapi-ios-dev-client</id>
                                 <client-name>Haapi iOS Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>haapi:start</redirect-uris>
+                                <redirect-uris>haapi://</redirect-uris>
                                 <user-authentication>
                                 </user-authentication>
                                 <scope>address</scope>
@@ -92,7 +92,7 @@
                                 <id>haapi-android-client</id>
                                 <client-name>Haapi Android Client</client-name>
                                 <no-authentication>true</no-authentication>
-                                <redirect-uris>app://haapi</redirect-uris>
+                                <redirect-uris>haapi://</redirect-uris>
                                 <audience>haapi-client</audience>
                                 <scope>address</scope>
                                 <scope>email</scope>

--- a/resources/base-config.xml
+++ b/resources/base-config.xml
@@ -4,6 +4,7 @@
       <base-url>#{RUNTIME_BASE_URL}</base-url>
       <admin-service>
         <http>
+          <base-url>https://localhost:6749</base-url>
           <ssl-server-keystore>default-admin-ssl-key</ssl-server-keystore>
           <web-ui/>
           <restconf>

--- a/resources/devops-dashboard.xml
+++ b/resources/devops-dashboard.xml
@@ -1,0 +1,163 @@
+<config xmlns="http://tail-f.com/ns/config/1.0">
+  <environments xmlns="https://curity.se/ns/conf/base">
+     <environment>
+        <admin-service>
+           <http>
+              <restconf>
+                <oauth xmlns="https://curity.se/ns/conf/profile/oauth">
+                  <oauth-profile>token-service</oauth-profile>
+                  <client>devops_dashboard_restconf_client</client>
+                </oauth>
+              </restconf>
+              <devops-dashboard xmlns="https://curity.se/ns/conf/profile/oauth">
+                <authorization-manager>dashboard_groups_authorization_manager</authorization-manager>
+                <client>devops_dashboard_restconf_client</client>
+              </devops-dashboard>
+           </http>
+        </admin-service>
+        <services>
+          <zones>
+            <default-zone>
+              <allowed-origins-for-cors>https://localhost:6749</allowed-origins-for-cors>
+            </default-zone>
+            </zones>
+          <service-role>
+            <id>default</id>
+            <endpoints>dashboard-management-admin</endpoints>
+            <endpoints>user-management-admin</endpoints>
+          </service-role>
+        </services>
+     </environment>
+  </environments>
+  <profiles xmlns="https://curity.se/ns/conf/base">
+    <profile>
+      <id>authentication-service</id>
+      <type xmlns:auth="https://curity.se/ns/conf/profile/authentication">auth:authentication-service</type>
+      <settings>
+        <authentication-service xmlns="https://curity.se/ns/conf/profile/authentication">
+          <authenticators>
+            <authenticator>
+              <id>username</id>
+              <username xmlns="https://curity.se/ns/ext-conf/username">
+              </username>
+            </authenticator>
+          </authenticators>
+        </authentication-service>
+      </settings>
+    </profile>
+    <profile>
+      <id>token-service</id>
+      <type xmlns:as="https://curity.se/ns/conf/profile/oauth">as:oauth-service</type>
+      <settings>
+        <authorization-server xmlns="https://curity.se/ns/conf/profile/oauth">
+          <scopes>
+            <scope>
+              <id>urn:se:curity:scopes:admin:api</id>
+              <claims>urn:se:curity:claims:admin:groups</claims>
+            </scope>
+          </scopes>
+          <claims>
+            <claim>
+              <name>urn:se:curity:claims:admin:groups</name>
+              <value-provided-by>devops_dashboard_admin_groups_claims_provider</value-provided-by>
+              <transformation>
+                <input-attribute-names>groups</input-attribute-names>
+                <value-transformation-procedure>ZnVuY3Rpb24gdHJhbnNmb3JtKGF0dHJpYnV0ZXMpIHsKICByZXR1cm4gYXR0cmlidXRlcy5ncm91cHM7Cn0=</value-transformation-procedure>
+              </transformation>
+            </claim>
+            <claims-value-provider>
+              <id>devops_dashboard_admin_groups_claims_provider</id>
+              <admin-groups-claims-provider xmlns="https://curity.se/ns/ext-conf/admin-groups-claims-provider" />
+            </claims-value-provider>
+            <claims-mappers>
+              <claims-mapper>
+                <id>default</id>
+                <access_token>
+                  <claim>urn:se:curity:claims:admin:groups</claim>
+                </access_token>
+              </claims-mapper>
+            </claims-mappers>
+          </claims>
+          <client-store>
+            <config-backed>
+              <client>
+                <id>devops_dashboard_restconf_client</id>
+                <client-name>DevOps Dashboard Client</client-name>
+                <description>The OAuth client that is used to login to the DevOps dashboard.</description>
+                <logo>data:image/svg+xml;base64,CjxzdmcgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjE2MHB4IgoJIGhlaWdodD0iMTYwcHgiIHZpZXdCb3g9IjAgMCA0My42IDQzLjYiIHN0eWxlPSJvdmVyZmxvdzp2aXNpYmxlO2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNDMuNiA0My42OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjtzdHJva2U6IzYyNkM4NztzdHJva2Utd2lkdGg6MS4xMDQ1O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDF7ZmlsbDojNjM2RDg2O30KCS5zdDJ7ZmlsbDojNjI2Qzg3O30KCS5zdDN7ZmlsbDpub25lO3N0cm9rZTojNjI2Qzg3O3N0cm9rZS13aWR0aDoxLjEwNDU7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQo8L3N0eWxlPgo8ZGVmcz4KPC9kZWZzPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMzksNDNINC42Yy0yLjIsMC00LTEuOC00LTRWNC42YzAtMi4yLDEuOC00LDQtNEgzOWMyLjIsMCw0LDEuOCw0LDRWMzlDNDMsNDEuMiw0MS4yLDQzLDM5LDQzeiIvPgo8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSI2LjQiIGN5PSI0LjQiIHI9IjEuNCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSIxMi4yIiBjeT0iNC40IiByPSIxLjQiLz4KPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iMTcuOSIgY3k9IjQuNCIgcj0iMS40Ii8+CjxnPgoJPGc+CgkJPHBhdGggY2xhc3M9InN0MiIgZD0iTTMxLjksMjZsLTAuMywwLjNjLTEuNSwxLjUtMy4zLDIuMy01LDIuM2MtMi43LDAtNC43LTItNC43LTQuOGMwLTIuOCwxLjktNC44LDQuNi00LjhjMS42LDAsMy40LDAuNyw0LjcsMS44CgkJCWwwLjMsMC4ybDIuNi0yLjdsLTAuMy0wLjJjLTItMS43LTQuOC0yLjctNy41LTIuN2MtMywwLTUuNSwxLjQtNywzLjVoLTQuN2wtMC4zLDIuM2gzLjljLTAuMSwwLjQtMC4yLDAuOS0wLjMsMS4zSDEybC0wLjMsMi4zCgkJCWg2LjFjMC4xLDAuNSwwLjEsMC45LDAuMywxLjNoMGgtMC4zSDkuM2wtMC4zLDIuM2g4LjdoMC4zaDEuMWMxLjUsMi4yLDQuMSwzLjUsNy4yLDMuNWMzLjksMCw2LjYtMiw3LjktMy4ybDAuMy0wLjNMMzEuOSwyNnoiLz4KCQk8cG9seWdvbiBjbGFzcz0ic3QyIiBwb2ludHM9IjExLjQsMjIuNiA5LjYsMjIuNiA5LjQsMjQuOSAxMS4xLDI0LjkgCQkiLz4KCTwvZz4KPC9nPgo8bGluZSBjbGFzcz0ic3QzIiB4MT0iMC42IiB5MT0iOC4zIiB4Mj0iNDMiIHkyPSI4LjMiLz4KPC9zdmc+Cg==</logo>
+                <no-authentication>true</no-authentication>
+                <redirect-uris>https://localhost:6749/admin/dashboard/assisted.html</redirect-uris>
+                <proof-key>
+                  <require-proof-key>true</require-proof-key>
+                </proof-key>
+                <refresh-token-ttl>disabled</refresh-token-ttl>
+                <audience>urn:se:curity:audiences:admin:api</audience>
+                <audience>devops_dashboard_restconf_client</audience>
+                <scope>openid</scope>
+                <scope>urn:se:curity:scopes:admin:api</scope>
+                <user-authentication>
+                  <allowed-authenticators>username</allowed-authenticators>
+                  <allowed-post-logout-redirect-uris>https://localhost:6749/admin/dashboard/assisted.html</allowed-post-logout-redirect-uris>
+                </user-authentication>
+                <allowed-origins>https://localhost:6749</allowed-origins>
+                <capabilities>
+                  <code />
+                </capabilities>
+              </client>
+            </config-backed>
+          </client-store>
+        </authorization-server>
+      </settings>
+    </profile>
+    <profile>
+      <id>user-management</id>
+      <type xmlns:um="https://curity.se/ns/conf/profile/user-management">um:user-management-service</type>
+      <expose-detailed-error-messages />
+      <settings>
+        <user-management-service xmlns="https://curity.se/ns/conf/profile/user-management">
+          <api-authentication>
+            <oauth-service>token-service</oauth-service>
+          </api-authentication>
+          <authorization-manager>dashboard_groups_authorization_manager</authorization-manager>
+          <user-account-data-source>default-datasource</user-account-data-source>
+          <token-data-source>default-datasource</token-data-source>
+           <credential-management>
+             <credential-manager>default-credential-manager</credential-manager>
+           </credential-management>
+         </user-management-service>
+      </settings>
+      <endpoints>
+        <endpoint>
+          <id>dashboard-management-admin</id>
+          <uri>/um/graphql/admin</uri>
+          <client-authentication>disallow</client-authentication>
+          <endpoint-kind>um-graphql-api</endpoint-kind>
+        </endpoint>
+        <endpoint>
+          <id>user-management-admin</id>
+          <uri>/um/admin</uri>
+          <endpoint-kind>um-api</endpoint-kind>
+        </endpoint>
+      </endpoints>
+    </profile>
+  </profiles>
+  <processing xmlns="https://curity.se/ns/conf/base">
+    <authorization-managers>
+      <authorization-manager>
+        <id>dashboard_groups_authorization_manager</id>
+        <groups xmlns="https://curity.se/ns/conf/authorization-manager/group">
+          <scope>urn:se:curity:scopes:admin:api</scope>
+          <group>
+            <name>admin</name>
+            <allows>
+              <create />
+              <read />
+              <update />
+              <delete />
+            </allows>
+          </group>
+        </groups>
+      </authorization-manager>
+    </authorization-managers>
+  </processing>
+</config>

--- a/resources/devops-dashboard.xml
+++ b/resources/devops-dashboard.xml
@@ -1,4 +1,4 @@
-<data xmlns="urn:ietf:params:xml:ns:yang:ietf-restconf">
+<config xmlns="http://tail-f.com/ns/config/1.0">
   <environments xmlns="https://curity.se/ns/conf/base">
      <environment>
         <admin-service>
@@ -160,4 +160,4 @@
       </authorization-manager>
     </authorization-managers>
   </processing>
-</data>
+</config>

--- a/resources/devops-dashboard.xml
+++ b/resources/devops-dashboard.xml
@@ -1,4 +1,4 @@
-<config xmlns="http://tail-f.com/ns/config/1.0">
+<data xmlns="urn:ietf:params:xml:ns:yang:ietf-restconf">
   <environments xmlns="https://curity.se/ns/conf/base">
      <environment>
         <admin-service>
@@ -160,4 +160,4 @@
       </authorization-manager>
     </authorization-managers>
   </processing>
-</config>
+</data>

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -24,7 +24,8 @@ services:
      - 8443:8443
     volumes:
      - ./license.json:/opt/idsvr/etc/init/license/license.json
-     - ./base-config.xml:/opt/idsvr/etc/init/config.xml
+     - ./base-config.xml:/opt/idsvr/etc/init/base-config.xml
+     - ./devops-dashboard.xml:/opt/idsvr/etc/init/devops-dashboard.xml
      - ./messages/attribute-prompt:/opt/idsvr/usr/share/messages/overrides/en/authentication-action/attribute-prompt/messages
      - ./customizations/htmlform.vm:/opt/idsvr/usr/share/templates/overrides/authenticator/html-form/authenticate/get.vm
     environment:

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -29,6 +29,6 @@ services:
      - ./messages/attribute-prompt:/opt/idsvr/usr/share/messages/overrides/en/authentication-action/attribute-prompt/messages
      - ./customizations/htmlform.vm:/opt/idsvr/usr/share/templates/overrides/authenticator/html-form/authenticate/get.vm
     environment:
-      PASSWORD: 'Password1'
+      ADMIN: 'true'
       RUNTIME_PROTOCOL: "${RUNTIME_PROTOCOL}"
       RUNTIME_BASE_URL: "${RUNTIME_BASE_URL}"

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     volumes:
      - ./license.json:/opt/idsvr/etc/init/license/license.json
      - ./base-config.xml:/opt/idsvr/etc/init/base-config.xml
-     - ./devops-dashboard.xml:/opt/idsvr/etc/init/devops-dashboard.xml
      - ./messages/attribute-prompt:/opt/idsvr/usr/share/messages/overrides/en/authentication-action/attribute-prompt/messages
      - ./customizations/htmlform.vm:/opt/idsvr/usr/share/templates/overrides/authenticator/html-form/authenticate/get.vm
     environment:

--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     volumes:
      - ./license.json:/opt/idsvr/etc/init/license/license.json
      - ./base-config.xml:/opt/idsvr/etc/init/base-config.xml
+     - ./devops-dashboard.xml:/opt/idsvr/etc/init/devops-dashboard.xml
      - ./messages/attribute-prompt:/opt/idsvr/usr/share/messages/overrides/en/authentication-action/attribute-prompt/messages
      - ./customizations/htmlform.vm:/opt/idsvr/usr/share/templates/overrides/authenticator/html-form/authenticate/get.vm
     environment:

--- a/start.sh
+++ b/start.sh
@@ -85,7 +85,8 @@ while [ "$(curl -k -s -o /dev/null -w ''%{http_code}'' -u "$ADMIN_USER:$ADMIN_PA
 done
 
 #
-# If the license allows it, use RESTCONF to activate the DevOps dashboard to enable test user administration.
+# For ngrok deployments, use RESTCONF to activate the DevOps dashboard to enable test user administration.
+# When the Curity Identity Server uses a host IP address the dashboard experiences SSL trust errors so we do not activate it.
 #
 base64url_decode() {
   local len=$((${#1} % 4))
@@ -96,22 +97,25 @@ base64url_decode() {
   echo "$result" | tr '_-' '/+' | base64 --decode
 }
 
-LICENSE_DATA=$(cat './license.json')
-LICENSE_JWT=$(echo $LICENSE_DATA | jq -r .License)
-LICENSE_PAYLOAD=$(base64url_decode $(echo $LICENSE_JWT | cut -d '.' -f 2))
-DASHBOARD=$(echo $LICENSE_PAYLOAD | jq -r '.Features[]  | select(.feature == "dashboard")')
-if [ "$DASHBOARD" != '' ]; then
+if [ "$USE_NGROK" == 'true' ]; then
 
-  echo 'Activating the DevOps dashboard ...'
-  HTTP_STATUS=$(curl -k -s \
-    -X PATCH "$RESTCONF_BASE_URL" \
-    -u "$ADMIN_USER:$ADMIN_PASSWORD" \
-    -H 'Content-Type: application/yang-data+xml' \
-    -d @devops-dashboard.xml \
-    -o /dev/null -w '%{http_code}')
-  if [ "$HTTP_STATUS" != '204' ]; then
-    echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
-    exit 1
+  LICENSE_DATA=$(cat './license.json')
+  LICENSE_JWT=$(echo $LICENSE_DATA | jq -r .License)
+  LICENSE_PAYLOAD=$(base64url_decode $(echo $LICENSE_JWT | cut -d '.' -f 2))
+  DASHBOARD=$(echo $LICENSE_PAYLOAD | jq -r '.Features[]  | select(.feature == "dashboard")')
+  if [ "$DASHBOARD" != '' ]; then
+
+    echo 'Activating the DevOps dashboard ...'
+    HTTP_STATUS=$(curl -k -s \
+      -X PATCH "$RESTCONF_BASE_URL" \
+      -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+      -H 'Content-Type: application/yang-data+xml' \
+      -d @devops-dashboard.xml \
+      -o /dev/null -w '%{http_code}')
+    if [ "$HTTP_STATUS" != '204' ]; then
+      echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
+      exit 1
+    fi
   fi
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -97,25 +97,24 @@ if [ "$EXAMPLE_NAME" == 'haapi' ]; then
   if [ "$ANDROID_PACKAGE_NAME" == '' ]; then
     ANDROID_PACKAGE_NAME='io.curity.haapidemo'
   fi
-
   if [ "$ANDROID_FINGERPRINT" == '' ]; then
     ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
   fi
   if [ "$ANDROID_SIGNATURE_DIGEST" == '' ]; then
     ANDROID_SIGNATURE_DIGEST='Z2DKEZO2XWFWQnApoRCzhqhIxzODe7BUsArj4Up9oKQ='
   fi
-  if [ "$APPLE_APP_ID" == '' ]; then
-    APPLE_APP_ID='io.curity.cat.ios.client'
+  if [ "$APPLE_BUNDLE_ID" == '' ]; then
+    APPLE_BUNDLE_ID='io.curity.haapidemo'
   fi
   if [ "$APPLE_TEAM_ID" == '' ]; then
     APPLE_TEAM_ID='MYTEAMID'
   fi
 
   export ANDROID_PACKAGE_NAME
-  export APPLE_APP_ID
-  export APPLE_TEAM_ID
   export ANDROID_FINGERPRINT
   export ANDROID_SIGNATURE_DIGEST
+  export APPLE_BUNDLE_ID
+  export APPLE_TEAM_ID
   envsubst < example-config-template.xml > example-config.xml
   if [ $? -ne 0 ]; then
     echo 'Problem encountered using envsubst to update example configuration'

--- a/start.sh
+++ b/start.sh
@@ -94,6 +94,10 @@ done
 cd ../$EXAMPLE_NAME
 if [ "$EXAMPLE_NAME" == 'haapi' ]; then
 
+  if [ "$ANDROID_PACKAGE_NAME" == '' ]; then
+    ANDROID_PACKAGE_NAME='io.curity.haapidemo'
+  fi
+
   if [ "$ANDROID_FINGERPRINT" == '' ]; then
     ANDROID_FINGERPRINT='67:60:CA:11:93:B6:5D:61:56:42:70:29:A1:10:B3:86:A8:48:C7:33:83:7B:B0:54:B0:0A:E3:E1:4A:7D:A0:A4'
   fi
@@ -107,6 +111,7 @@ if [ "$EXAMPLE_NAME" == 'haapi' ]; then
     APPLE_TEAM_ID='MYTEAMID'
   fi
 
+  export ANDROID_PACKAGE_NAME
   export APPLE_APP_ID
   export APPLE_TEAM_ID
   export ANDROID_FINGERPRINT

--- a/start.sh
+++ b/start.sh
@@ -85,21 +85,37 @@ while [ "$(curl -k -s -o /dev/null -w ''%{http_code}'' -u "$ADMIN_USER:$ADMIN_PA
 done
 
 #
-# For ngrok deployments, use RESTCONF to activate the DevOps dashboard to enable test user administration
-# When the Curity Identity Server uses a host IP address the dashboard experiences SSL trust errors so we do not activate it
+# For ngrok deployments, use RESTCONF to activate the DevOps dashboard to enable test user administration.
+# When the Curity Identity Server uses a host IP address the dashboard experiences SSL trust errors so we do not activate it.
 #
+base64url_decode() {
+  local len=$((${#1} % 4))
+  local result="$1"
+  if [ $len -eq 2 ]; then result="$1"'=='
+  elif [ $len -eq 3 ]; then result="$1"'=' 
+  fi
+  echo "$result" | tr '_-' '/+' | base64 --decode
+}
+
 if [ "$USE_NGROK" == 'true' ]; then
 
-  echo 'Activating the DevOps dashboard ...'
-  HTTP_STATUS=$(curl -k -s \
-    -X PATCH "$RESTCONF_BASE_URL" \
-    -u "$ADMIN_USER:$ADMIN_PASSWORD" \
-    -H 'Content-Type: application/yang-data+xml' \
-    -d @devops-dashboard.xml \
-    -o /dev/null -w '%{http_code}')
-  if [ "$HTTP_STATUS" != '204' ]; then
-    echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
-    exit 1
+  LICENSE_DATA=$(cat './license.json')
+  LICENSE_JWT=$(echo $LICENSE_DATA | jq -r .License)
+  LICENSE_PAYLOAD=$(base64url_decode $(echo $LICENSE_JWT | cut -d '.' -f 2))
+  DASHBOARD=$(echo $LICENSE_PAYLOAD | jq -r '.Features[]  | select(.feature == "dashboard")')
+  if [ "$DASHBOARD" != '' ]; then
+
+    echo 'Activating the DevOps dashboard ...'
+    HTTP_STATUS=$(curl -k -s \
+      -X PATCH "$RESTCONF_BASE_URL" \
+      -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+      -H 'Content-Type: application/yang-data+xml' \
+      -d @devops-dashboard.xml \
+      -o /dev/null -w '%{http_code}')
+    if [ "$HTTP_STATUS" != '204' ]; then
+      echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
+      exit 1
+    fi
   fi
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -85,25 +85,6 @@ while [ "$(curl -k -s -o /dev/null -w ''%{http_code}'' -u "$ADMIN_USER:$ADMIN_PA
 done
 
 #
-# For ngrok deployments, use RESTCONF to activate the DevOps dashboard to enable test user administration
-# When the Curity Identity Server uses a host IP address the dashboard experiences SSL trust errors so we do not activate it
-#
-if [ "$USE_NGROK" == 'true' ]; then
-
-  echo 'Activating the DevOps dashboard ...'
-  HTTP_STATUS=$(curl -k -s \
-    -X PATCH "$RESTCONF_BASE_URL" \
-    -u "$ADMIN_USER:$ADMIN_PASSWORD" \
-    -H 'Content-Type: application/yang-data+xml' \
-    -d @devops-dashboard.xml \
-    -o /dev/null -w '%{http_code}')
-  if [ "$HTTP_STATUS" != '204' ]; then
-    echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
-    exit 1
-  fi
-fi
-
-#
 # For the HAAPI example, update configuration dynamically based on additional environment variables 
 #
 cd ../$EXAMPLE_NAME

--- a/start.sh
+++ b/start.sh
@@ -85,6 +85,25 @@ while [ "$(curl -k -s -o /dev/null -w ''%{http_code}'' -u "$ADMIN_USER:$ADMIN_PA
 done
 
 #
+# For ngrok deployments, use RESTCONF to activate the DevOps dashboard to enable test user administration
+# When the Curity Identity Server uses a host IP address the dashboard experiences SSL trust errors so we do not activate it
+#
+if [ "$USE_NGROK" == 'true' ]; then
+
+  echo 'Activating the DevOps dashboard ...'
+  HTTP_STATUS=$(curl -k -s \
+    -X PATCH "$RESTCONF_BASE_URL" \
+    -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+    -H 'Content-Type: application/yang-data+xml' \
+    -d @devops-dashboard.xml \
+    -o /dev/null -w '%{http_code}')
+  if [ "$HTTP_STATUS" != '204' ]; then
+    echo "Problem encountered applying the DevOps Dashboard configuration: $HTTP_STATUS"
+    exit 1
+  fi
+fi
+
+#
 # For the HAAPI example, update configuration dynamically based on additional environment variables 
 #
 cd ../$EXAMPLE_NAME


### PR DESCRIPTION
This repo is used to deploy 8 separate code examples and should ensure an equivalent experience:

- Use the DevOps dashboard to create test users
- Use a SQL database to query identity data.

However, HAAPI examples need some autonomy:

- Avoid breaking old model SDK examples.
- Use the most business like settings in newer UI SDK code examples.
- Allow professional services to customize their React Native deployment.

I did some consolidation to:

- Update the README to make the role of this repo clearer
- Activate the DevOps dashboard when it will work reliably